### PR TITLE
fix: record install results so summary and receipt show real data

### DIFF
--- a/config/rog-ally/lib/winget-helpers.ps1
+++ b/config/rog-ally/lib/winget-helpers.ps1
@@ -81,6 +81,9 @@ function Install-WingetPackage {
         if ($installed -match $PackageId) {
             Write-Status "$Name already installed - skipping" "Success"
             & $completeLog "skipped"
+            if (-not $Script:DryRun -and (Get-Command Add-InstallResult -ErrorAction SilentlyContinue)) {
+                Add-InstallResult -PackageId $PackageId -Name $Name -Status 'skipped' -Source ''
+            }
             return $true
         }
     } catch {
@@ -172,6 +175,9 @@ function Install-WingetPackage {
         } elseif ($result.ExitCode -eq 0) {
             Write-Status "$Name installed (winget)" "Success"
             & $completeLog "success"
+            if (Get-Command Add-InstallResult -ErrorAction SilentlyContinue) {
+                Add-InstallResult -PackageId $PackageId -Name $Name -Status 'succeeded' -Source 'winget'
+            }
             return $true
         } else {
             Write-Host "    Winget source failed (exit code $($result.ExitCode))" -ForegroundColor Yellow
@@ -197,6 +203,9 @@ function Install-WingetPackage {
                 if (-not $result.TimedOut -and $result.ExitCode -eq 0) {
                     Write-Status "$Name installed (winget after source reset)" "Success"
                     & $completeLog "success"
+                    if (Get-Command Add-InstallResult -ErrorAction SilentlyContinue) {
+                        Add-InstallResult -PackageId $PackageId -Name $Name -Status 'succeeded' -Source 'winget'
+                    }
                     return $true
                 }
                 Write-Host "    Retry after source reset failed (exit code $($result.ExitCode))" -ForegroundColor Yellow
@@ -214,6 +223,9 @@ function Install-WingetPackage {
         } elseif ($result.ExitCode -eq 0) {
             Write-Status "$Name installed (msstore fallback)" "Success"
             & $completeLog "success"
+            if (Get-Command Add-InstallResult -ErrorAction SilentlyContinue) {
+                Add-InstallResult -PackageId $PackageId -Name $Name -Status 'succeeded' -Source 'msstore'
+            }
             return $true
         } else {
             Write-Host "    msstore also failed (exit code $($result.ExitCode))" -ForegroundColor Red
@@ -227,6 +239,9 @@ function Install-WingetPackage {
         foreach ($line in $errorLines) {
             Write-Host "    $line" -ForegroundColor Yellow
         }
+    }
+    if (Get-Command Add-InstallResult -ErrorAction SilentlyContinue) {
+        Add-InstallResult -PackageId $PackageId -Name $Name -Status 'failed' -Source '' -Message 'all sources failed or timed out'
     }
     & $completeLog "failed"
     return $false

--- a/config/rog-ally/modules/rog_ally.ps1
+++ b/config/rog-ally/modules/rog_ally.ps1
@@ -116,6 +116,9 @@ if (Get-ConfigValue "install_ghelper" $false) {
 
         if (Test-Path $gHelperExe) {
             Write-Status "G-Helper already installed - skipping" "Success"
+            if (Get-Command Add-InstallResult -ErrorAction SilentlyContinue) {
+                Add-InstallResult -PackageId 'seerge/g-helper' -Name 'G-Helper' -Status 'skipped' -Source 'direct'
+            }
         } elseif ($Script:DryRun) {
             Write-Status "[DRY RUN] Would install G-Helper (Armoury Crate alternative) from GitHub releases" "Info"
         } else {
@@ -152,6 +155,9 @@ if (Get-ConfigValue "install_ghelper" $false) {
                     if (Test-Path $gHelperExe) {
                         Set-ItemProperty -Path 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run' -Name 'GHelper' -Value "`"$gHelperExe`""
                         Write-Status "G-Helper $($release.Tag) installed (autostarts at login)" "Success"
+                        if (Get-Command Add-InstallResult -ErrorAction SilentlyContinue) {
+                            Add-InstallResult -PackageId 'seerge/g-helper' -Name 'G-Helper' -Status 'succeeded' -Source 'direct'
+                        }
                         if (Get-Command Add-AppliedChange -ErrorAction SilentlyContinue) {
                             Add-AppliedChange "G-Helper $($release.Tag) installed (autostart at login)"
                         }
@@ -167,6 +173,9 @@ if (Get-ConfigValue "install_ghelper" $false) {
                 } catch {
                     Write-Status "Failed to install G-Helper: $_" "Warning"
                     Write-Status "Install manually: https://github.com/seerge/g-helper/releases" "Info"
+                    if (Get-Command Add-InstallResult -ErrorAction SilentlyContinue) {
+                        Add-InstallResult -PackageId 'seerge/g-helper' -Name 'G-Helper' -Status 'failed' -Source 'direct' -Message $_.Exception.Message
+                    }
                 } finally {
                     $ProgressPreference = $prevProgressPreference
                     Remove-Item $zipFile -Force -ErrorAction SilentlyContinue

--- a/config/rog-ally/modules/rog_ally.ps1
+++ b/config/rog-ally/modules/rog_ally.ps1
@@ -116,7 +116,7 @@ if (Get-ConfigValue "install_ghelper" $false) {
 
         if (Test-Path $gHelperExe) {
             Write-Status "G-Helper already installed - skipping" "Success"
-            if (Get-Command Add-InstallResult -ErrorAction SilentlyContinue) {
+            if (-not $Script:DryRun -and (Get-Command Add-InstallResult -ErrorAction SilentlyContinue)) {
                 Add-InstallResult -PackageId 'seerge/g-helper' -Name 'G-Helper' -Status 'skipped' -Source 'direct'
             }
         } elseif ($Script:DryRun) {

--- a/tests/Install-WingetPackage.Tests.ps1
+++ b/tests/Install-WingetPackage.Tests.ps1
@@ -274,4 +274,98 @@ Describe "Install-WingetPackage" {
             Should -Invoke Start-Job -Times 1
         }
     }
+
+    Context "Result recording" {
+        BeforeEach {
+            $Script:DryRun = $false
+            $Script:HasWingetSource = $true
+            $Script:HasMsStoreSource = $true
+            $Script:WingetSourceRecovered = $false
+
+            # Provide a stub so Mock has a target when running outside Run.ps1
+            if (-not (Get-Command Add-InstallResult -ErrorAction SilentlyContinue)) {
+                function script:Add-InstallResult {
+                    param(
+                        [string]$PackageId,
+                        [string]$Name,
+                        [string]$Status,
+                        [string]$Source = '',
+                        [string]$Message = ''
+                    )
+                }
+            }
+
+            Mock winget { return "" } -ParameterFilter { ($args -join ' ') -match 'list --id' }
+            Mock Add-InstallResult { }
+        }
+
+        It "Records skipped when package already installed" {
+            Mock winget {
+                return "Test.Package  1.0.0  winget"
+            } -ParameterFilter { ($args -join ' ') -match 'list --id Test\.Package' }
+
+            Install-WingetPackage -PackageId "Test.Package" -Name "Test Package" | Out-Null
+
+            Should -Invoke Add-InstallResult -Times 1 -Exactly -ParameterFilter {
+                $Status -eq 'skipped' -and $PackageId -eq 'Test.Package'
+            }
+        }
+
+        It "Records succeeded with Source winget on winget install success" {
+            Mock Start-Job { [PSCustomObject]@{ Id = 1; State = 'Running' } }
+            Mock Wait-Job { $true }
+            Mock Receive-Job { @{ ExitCode = 0; Output = "Successfully installed" } }
+            Mock Remove-Job { }
+
+            Install-WingetPackage -PackageId "Test.Package" -Name "Test Package" | Out-Null
+
+            Should -Invoke Add-InstallResult -Times 1 -Exactly -ParameterFilter {
+                $Status -eq 'succeeded' -and $Source -eq 'winget'
+            }
+        }
+
+        It "Records succeeded with Source msstore on msstore fallback success" {
+            $script:jobCounter = 0
+            Mock Start-Job {
+                $script:jobCounter++
+                [PSCustomObject]@{ Id = $script:jobCounter; State = 'Running' }
+            }
+            Mock Wait-Job { $true }
+            Mock Receive-Job { @{ ExitCode = 1; Output = "Winget failed" } } -ParameterFilter { $Id -eq 1 }
+            Mock Receive-Job { @{ ExitCode = 0; Output = "msstore success" } } -ParameterFilter { $Id -eq 2 }
+            Mock Remove-Job { }
+
+            Install-WingetPackage -PackageId "Test.Package" -Name "Test Package" | Out-Null
+
+            Should -Invoke Add-InstallResult -Times 1 -Exactly -ParameterFilter {
+                $Status -eq 'succeeded' -and $Source -eq 'msstore'
+            }
+        }
+
+        It "Records failed with non-empty Message when all sources fail" {
+            Mock Start-Job { [PSCustomObject]@{ Id = 1; State = 'Running' } }
+            Mock Wait-Job { $true }
+            Mock Receive-Job { @{ ExitCode = 1; Output = "All failed" } }
+            Mock Remove-Job { }
+
+            Install-WingetPackage -PackageId "Test.Package" -Name "Test Package" | Out-Null
+
+            Should -Invoke Add-InstallResult -Times 1 -Exactly -ParameterFilter {
+                $Status -eq 'failed' -and $Message -ne ''
+            }
+        }
+
+        It "Does not call Add-InstallResult during dry run validate-found path" {
+            $Script:DryRun = $true
+
+            Mock winget {
+                $global:LASTEXITCODE = 0
+                return "Found Test.Package"
+            } -ParameterFilter { ($args -join ' ') -match 'show --id.*--source winget' }
+
+            Install-WingetPackage -PackageId "Test.Package" -Name "Test Package" | Out-Null
+
+            Should -Invoke Add-InstallResult -Times 0 -Exactly
+        }
+    }
 }

--- a/tests/Install-WingetPackage.Tests.ps1
+++ b/tests/Install-WingetPackage.Tests.ps1
@@ -342,6 +342,26 @@ Describe "Install-WingetPackage" {
             }
         }
 
+        It "Records succeeded with Source winget exactly once on post-recovery retry success" {
+            $script:jobCounter = 0
+            Mock Start-Job {
+                $script:jobCounter++
+                [PSCustomObject]@{ Id = $script:jobCounter; State = 'Running' }
+            }
+            Mock Wait-Job { $true }
+            Mock Receive-Job { @{ ExitCode = -2145844748; Output = "Failed when opening source(s); try the 'source reset' command if the problem persists." } } -ParameterFilter { $Id -eq 1 }
+            Mock Receive-Job { @{ ExitCode = 0; Output = "Successfully installed" } } -ParameterFilter { $Id -eq 2 }
+            Mock Remove-Job { }
+            Mock winget { return "" } -ParameterFilter { ($args -join ' ') -match 'source (reset|update)' }
+
+            Install-WingetPackage -PackageId "Test.Package" -Name "Test Package" | Out-Null
+
+            Should -Invoke Add-InstallResult -Times 1 -Exactly -ParameterFilter {
+                $Status -eq 'succeeded' -and $Source -eq 'winget'
+            }
+            Should -Invoke Add-InstallResult -Times 1 -Exactly
+        }
+
         It "Records failed with non-empty Message when all sources fail" {
             Mock Start-Job { [PSCustomObject]@{ Id = 1; State = 'Running' } }
             Mock Wait-Job { $true }


### PR DESCRIPTION
## Summary

- `Add-InstallResult` has been defined-but-never-called since January — its call-site wiring lived on a swarm branch that never merged. `Write-Summary` has printed zeros and the Desktop receipt's Apps section has been empty at runtime ever since.
- Wires result recording into `Install-WingetPackage`'s terminal outcomes (already-installed → skipped, winget success incl. post-source-recovery, msstore fallback, all-failed with message) and the G-Helper direct-download block.
- Guarded for standalone lib testability; zero recording on any dry-run path (verified: `Add-InstallResult` has no internal dry-run guard).
- 6 new invocation tests pin call-site behavior (`Should -Invoke` per path, incl. exactly-once on the recovery sequence).

## Test Plan
- [x] 98/0 locally (was 92)
- [x] Analyzer Error-clean, ASCII-clean on touched files
- [ ] CI green on windows-latest

Lands before the Saturday RC run so the receipt validates with real data.